### PR TITLE
Add setting file for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,6 @@ script: mvn clean test
 branches:
   only:
     - master
-
+matrix:
+  allow_failures:
+   - jdk: oraclejdk8


### PR DESCRIPTION
[Travis CI](https://travis-ci.org/)でテストするための設定を追加

自分のリポジトリで動作確認はできてるので( https://travis-ci.org/sue445/jenkins-chatwork-plugin )、あとはそちらのリポジトリで設定すれば動くはずです。

詳しい設定方法
http://sue445.hatenablog.com/entry/2013/06/01/170607

一応JDK 6〜8でテストするようにはしてますが、JDK8だとテストハーネスに組み込まれてるテストが落ちるため `allow_failures` をつけてます（6と7だとテストは動く）
https://travis-ci.org/sue445/jenkins-chatwork-plugin/jobs/25085731
