### PR TITLE
Support Jenkins build variables and shell variables in chatwork post message

### DIFF
--- a/src/main/java/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/BuildVariableUtil.java
+++ b/src/main/java/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/BuildVariableUtil.java
@@ -1,0 +1,29 @@
+package com.vexus2.jenkins.chatwork.jenkinschatworkplugin;
+
+import hudson.EnvVars;
+import hudson.Util;
+import hudson.model.AbstractBuild;
+import hudson.model.TaskListener;
+import hudson.util.VariableResolver;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class BuildVariableUtil {
+  public static String resolve(String source, AbstractBuild build, TaskListener listener) {
+    return resolve(source, build, listener, new HashMap<String, String>());
+  }
+
+  public static String resolve(String source, AbstractBuild build, TaskListener listener, Map<String, String> extraVariables) {
+    VariableResolver<String> buildVariableResolver = build.getBuildVariableResolver();
+    String resolved = Util.replaceMacro(source, buildVariableResolver);
+
+    try {
+      EnvVars envVars = build.getEnvironment(listener);
+      envVars.putAll(extraVariables);
+      return envVars.expand(resolved);
+    } catch (Exception e) {
+      return resolved;
+    }
+  }
+}

--- a/src/test/groovy/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/BuildVariableUtilTest.groovy
+++ b/src/test/groovy/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/BuildVariableUtilTest.groovy
@@ -1,0 +1,54 @@
+package com.vexus2.jenkins.chatwork.jenkinschatworkplugin
+
+import hudson.EnvVars
+import hudson.model.AbstractBuild
+import hudson.model.TaskListener
+import hudson.util.LogTaskListener
+import org.junit.Before
+import org.junit.Test
+import org.junit.experimental.runners.Enclosed
+import org.junit.runner.RunWith
+
+import java.util.logging.Level
+import java.util.logging.Logger
+
+import static org.mockito.Mockito.*
+
+@RunWith(Enclosed)
+class BuildVariableUtilTest {
+  static class resolve {
+    AbstractBuild mockBuild
+    TaskListener listener
+    Map<String, String> extraVariables;
+
+    static final Logger LOGGER = Logger.getLogger(BuildVariableUtilTest.class.getName());
+
+    @Before
+    void setUp(){
+      listener = new LogTaskListener(LOGGER, Level.INFO)
+      mockBuild = mock(AbstractBuild)
+      when(mockBuild.getEnvironment(any(TaskListener))).thenReturn(new EnvVars(['JAVA_HOME': '/Library/Java/JavaVirtualMachines/1.7.0u.jdk/Contents/Home']))
+      when(mockBuild.getBuildVariables()).thenReturn(['BUILD_NUMBER': '123'])
+
+      extraVariables = ["BUILD_RESULT": "SUCCESS"]
+    }
+
+    @Test
+    void 'should resolve build variable'(){
+      String source = 'BUILD_NUMBER is $BUILD_NUMBER'
+      assert BuildVariableUtil.resolve(source, mockBuild, listener, extraVariables) == "BUILD_NUMBER is 123"
+    }
+
+    @Test
+    void 'should resolve environment variable'(){
+      String source = 'JAVA_HOME is $JAVA_HOME'
+      assert BuildVariableUtil.resolve(source, mockBuild, listener, extraVariables) == "JAVA_HOME is /Library/Java/JavaVirtualMachines/1.7.0u.jdk/Contents/Home"
+    }
+
+    @Test
+    void 'should resolve extra variable'(){
+      String source = 'BUILD_RESULT is $BUILD_RESULT'
+      assert BuildVariableUtil.resolve(source, mockBuild, listener, extraVariables) == "BUILD_RESULT is SUCCESS"
+    }
+  }
+}

--- a/src/test/groovy/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisherTest.groovy
+++ b/src/test/groovy/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisherTest.groovy
@@ -1,8 +1,16 @@
 package com.vexus2.jenkins.chatwork.jenkinschatworkplugin
 
+import hudson.EnvVars
+import hudson.model.AbstractBuild
+import hudson.model.Result
+import hudson.model.TaskListener
+import org.junit.Before
 import org.junit.Test
 import org.junit.experimental.runners.Enclosed
 import org.junit.runner.RunWith
+
+import static org.mockito.Matchers.any
+import static org.mockito.Mockito.*
 
 @RunWith(Enclosed)
 class ChatworkPublisherTest {
@@ -76,6 +84,189 @@ https://github.com/octocat/Hello-World/compare/master...topic
 """
 
       assert ChatworkPublisher.analyzePayload(parameterDefinition) == null
+    }
+  }
+
+  static class createMessage {
+    ChatworkPublisher publisher
+    AbstractBuild mockBuild
+
+    @Before
+    void setUp(){
+      // via. https://gist.github.com/gjtorikian/5171861
+      String payload = """
+{
+   "after":"1481a2de7b2a7d02428ad93446ab166be7793fbb",
+   "before":"17c497ccc7cca9c2f735aa07e9e3813060ce9a6a",
+   "commits":[
+      {
+         "added":[
+
+         ],
+         "author":{
+            "email":"lolwut@noway.biz",
+            "name":"Garen Torikian",
+            "username":"octokitty"
+         },
+         "committer":{
+            "email":"lolwut@noway.biz",
+            "name":"Garen Torikian",
+            "username":"octokitty"
+         },
+         "distinct":true,
+         "id":"c441029cf673f84c8b7db52d0a5944ee5c52ff89",
+         "message":"Test",
+         "modified":[
+            "README.md"
+         ],
+         "removed":[
+
+         ],
+         "timestamp":"2013-02-22T13:50:07-08:00",
+         "url":"https://github.com/octokitty/testing/commit/c441029cf673f84c8b7db52d0a5944ee5c52ff89"
+      },
+      {
+         "added":[
+
+         ],
+         "author":{
+            "email":"lolwut@noway.biz",
+            "name":"Garen Torikian",
+            "username":"octokitty"
+         },
+         "committer":{
+            "email":"lolwut@noway.biz",
+            "name":"Garen Torikian",
+            "username":"octokitty"
+         },
+         "distinct":true,
+         "id":"36c5f2243ed24de58284a96f2a643bed8c028658",
+         "message":"This is me testing the windows client.",
+         "modified":[
+            "README.md"
+         ],
+         "removed":[
+
+         ],
+         "timestamp":"2013-02-22T14:07:13-08:00",
+         "url":"https://github.com/octokitty/testing/commit/36c5f2243ed24de58284a96f2a643bed8c028658"
+      },
+      {
+         "added":[
+            "words/madame-bovary.txt"
+         ],
+         "author":{
+            "email":"lolwut@noway.biz",
+            "name":"Garen Torikian",
+            "username":"octokitty"
+         },
+         "committer":{
+            "email":"lolwut@noway.biz",
+            "name":"Garen Torikian",
+            "username":"octokitty"
+         },
+         "distinct":true,
+         "id":"1481a2de7b2a7d02428ad93446ab166be7793fbb",
+         "message":"Rename madame-bovary.txt to words/madame-bovary.txt",
+         "modified":[
+
+         ],
+         "removed":[
+            "madame-bovary.txt"
+         ],
+         "timestamp":"2013-03-12T08:14:29-07:00",
+         "url":"https://github.com/octokitty/testing/commit/1481a2de7b2a7d02428ad93446ab166be7793fbb"
+      }
+   ],
+   "compare":"https://github.com/octokitty/testing/compare/17c497ccc7cc...1481a2de7b2a",
+   "created":false,
+   "deleted":false,
+   "forced":false,
+   "head_commit":{
+      "added":[
+         "words/madame-bovary.txt"
+      ],
+      "author":{
+         "email":"lolwut@noway.biz",
+         "name":"Garen Torikian",
+         "username":"octokitty"
+      },
+      "committer":{
+         "email":"lolwut@noway.biz",
+         "name":"Garen Torikian",
+         "username":"octokitty"
+      },
+      "distinct":true,
+      "id":"1481a2de7b2a7d02428ad93446ab166be7793fbb",
+      "message":"Rename madame-bovary.txt to words/madame-bovary.txt",
+      "modified":[
+
+      ],
+      "removed":[
+         "madame-bovary.txt"
+      ],
+      "timestamp":"2013-03-12T08:14:29-07:00",
+      "url":"https://github.com/octokitty/testing/commit/1481a2de7b2a7d02428ad93446ab166be7793fbb"
+   },
+   "pusher":{
+      "email":"lolwut@noway.biz",
+      "name":"Garen Torikian"
+   },
+   "ref":"refs/heads/master",
+   "repository":{
+      "created_at":1332977768,
+      "description":"",
+      "fork":false,
+      "forks":0,
+      "has_downloads":true,
+      "has_issues":true,
+      "has_wiki":true,
+      "homepage":"",
+      "id":3860742,
+      "language":"Ruby",
+      "master_branch":"master",
+      "name":"testing",
+      "open_issues":2,
+      "owner":{
+         "email":"lolwut@noway.biz",
+         "name":"octokitty"
+      },
+      "private":false,
+      "pushed_at":1363295520,
+      "size":2156,
+      "stargazers":1,
+      "url":"https://github.com/octokitty/testing",
+      "watchers":1
+   }
+}
+"""
+
+      String roomId = "00000000"
+      String defaultMessage = '$PAYLOAD_SUMMARY'
+      boolean notifyOnSuccess = true
+      boolean notifyOnFail = true
+      publisher = new ChatworkPublisher(roomId, defaultMessage, notifyOnSuccess, notifyOnFail)
+
+      mockBuild = mock(AbstractBuild)
+      when(mockBuild.getBuildVariables()).thenReturn(['payload': payload])
+      when(mockBuild.getEnvironment(any(TaskListener))).thenReturn(new EnvVars(['JAVA_HOME': '/Library/Java/JavaVirtualMachines/1.7.0u.jdk/Contents/Home']))
+      when(mockBuild.getResult()).thenReturn(Result.SUCCESS)
+
+      publisher.build = mockBuild
+    }
+
+    @Test
+    void "When contains payload param, should resolve payload"(){
+      String excepted = """
+Garen Torikian pushed into testing,
+- Test
+- This is me testing the windows client.
+- Rename madame-bovary.txt to words/madame-bovary.tx...
+
+https://github.com/octokitty/testing/compare/17c497ccc7cc...1481a2de7b2a
+""".trim()
+
+      assert publisher.createMessage() == excepted
     }
   }
 }


### PR DESCRIPTION
chatworkにpostするメッセージでJenkinsのビルド変数やシェルの環境変数などを埋め込めるようにしました。

```
[info][title]${JOB_NAME} ${BUILD_DISPLAY_NAME}[/title]
build is  ${BUILD_RESULT}
${BUILD_URL}
[/info]
```

こういう風に書くとChatWorkでは

![jenkins_up](https://cloud.githubusercontent.com/assets/608755/3075215/44ed08b4-e36b-11e3-8ff2-936e98d4821c.png)

のように表示されます。
## 細かい修正内容
- 正規表現を駆使して個別に埋め込み変数をparseしてたところを、Jenkins自身のメソッドを使うようにしてます( `BuildVariableUtil` 辺りの実装)
  - 既存だとビルドパラメータしか取得できなかったですが、シェルやJenkinsの環境変数も一通り取得できるようになりました
  - ただしビルドパラメータの `payload` とdefault message中に含める埋め込み変数としての `$payload` が競合してしまったため（`$payload` を埋め込むと `analyzePayload` で整形したメッセージではなくビルドパラメータで渡されたjsonのpayloadが埋め込まれる）、default messageの埋め込み変数の方を `$PAYLOAD_SUMMARY` に変えています。
- 既存のビルド変数だとビルド結果（SUCCESSとかFAILURE）を取得する変数がなかったので　`$BUILD_RESULT` で取得できるようにしました
- payloadがjson以外の時にエラーになってたのでエラーにならないように修正
- その他細かいリファクタリング
