### PR TITLE
Add NOPROXY note

### DIFF
--- a/src/main/resources/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisher/global.jelly
+++ b/src/main/resources/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisher/global.jelly
@@ -19,6 +19,7 @@
     <f:entry title="Proxy server" field="proxysv"
       description="Set your Proxy server">
       <f:textbox default="NOPROXY"/>
+      If you don't want to use proxy, set "NOPROXY"
     </f:entry>
     <f:entry title="Proxy port" field="proxyport"
       description="Set your Proxy port">


### PR DESCRIPTION
Proxy setting feature is added by #6 

If we want to use proxy, we must set "NOPROXY". But this specification is not written anywhere. This is confusing!

So I wrote this note.

![2014-09-18 0 59 01](https://cloud.githubusercontent.com/assets/608755/4306894/74988ccc-3e84-11e4-8657-be883896a9b5.png)
