### PR TITLE
Fix: Failed to serialize

### DIFF
--- a/src/main/java/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisher.java
+++ b/src/main/java/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisher.java
@@ -27,8 +27,8 @@ public class ChatworkPublisher extends Publisher {
 
   private Boolean notifyOnSuccess;
   private Boolean notifyOnFail;
-  private AbstractBuild build;
-  private BuildListener listener;
+  private transient AbstractBuild build;
+  private transient BuildListener listener;
 
 
   // Fields in config.jelly must match the parameter names in the "DataBoundConstructor"


### PR DESCRIPTION
（英語で説明できるかどうか怪しかったので日本語で失礼します）

Jenkinsグローバル設定やジョブ設定をファイルに保存する時に高確率でシリアライズエラーになる（一度起きるとサーバを再起動しないと解消しない）バグを修正しています。

スタックトレース
https://gist.github.com/sue445/9dedd61faab63a87c880

設定保存時にJenkinsがインスタンス変数をシリアライズしてファイルに書きだそうとしてるのですが、プラグインの設定とは関係ないインスタンス（ ジョブ実行時に作られる `build` と `listener` ）をシリアライズしようとしてエラーになってた模様です。

自分のJenkinsで数日間試用してみてエラーが再発しなくなったのを確認したのでPRを投げます。

本来ならシリアライズすべきでないものはインスタンス変数に持たせないのが正解だと思うのですが、インスタンス変数で持たせるのをやめると `build` と `listener` を引数で持ち回すことになり冗長になるので `transient` をつけてシリアライズ対象外にしています。
